### PR TITLE
Reformat Javadocs

### DIFF
--- a/src/main/java/me/sparky983/helios/Optional.java
+++ b/src/main/java/me/sparky983/helios/Optional.java
@@ -11,9 +11,9 @@ import me.sparky983.helios.annotations.Nullable;
  * Traditionally in Java, {@code null} was used to represent the absence of a value. However, this
  * has many shortcomings:
  * <ul>
- *     <li>{@code null} inherently leads to {@link java.lang.NullPointerException}s</li>
- *     <li>{@code null} is not type-safe</li>
- *     <li>{@code null} is not nestable</li>
+ *   <li>{@code null} inherently leads to {@link java.lang.NullPointerException}s</li>
+ *   <li>{@code null} is not type-safe</li>
+ *   <li>{@code null} is not nestable</li>
  * </ul>
  * <h2>Optional</h2>
  * These problems are solved by using {@code Optional}. {@code Optional} provides a type-safe way of
@@ -21,15 +21,15 @@ import me.sparky983.helios.annotations.Nullable;
  * <p>
  * An {@code Optional} can be in one of two states:
  * <ul>
- *     <li>{@link Present}</li>
- *     <li>and {@link Absent}</li>
+ *   <li>{@link Present}</li>
+ *   <li>and {@link Absent}</li>
  * </ul>
  * {@snippet :
- * Optional<Integer> present = Optional.present(5);
- * assert optional.isPresent();
+ *   Optional<Integer> present = Optional.present(5);
+ *   assert optional.isPresent();
  *
- * Optional<Integer> absent = Optional.absent();
- * assert absent.isAbsent();
+ *   Optional<Integer> absent = Optional.absent();
+ *   assert absent.isAbsent();
  * }
  * <p>
  * Unlike {@code null}, the type system enforces that a references wrapped in {@code Optional}
@@ -37,84 +37,72 @@ import me.sparky983.helios.annotations.Nullable;
  * <p>
  * The methods for querying the value are provided by {@code Optional}:
  * <table border="1">
- *     <caption>Querying Methods</caption>
- *     <tr>
- *         <th>Method</th>
- *         <th>Receiver</th>
- *         <th>Input</th>
- *         <th>Output</th>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link
- *             Optional#or(Optional)}
- *         </td>
- *         <td>{@code Optional.present(value)}</td>
- *         <td>{@code Optional.present(other)}</td>
- *         <td>{@code Optional.present(value)}</td>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link
- *             Optional#or(Optional)}
- *         </td>
- *         <td>{@code Optional.present(value)}</td>
- *         <td>{@code Optional.absent()}</td>
- *         <td>{@code Optional.present(value)}</td>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link
- *             Optional#or(Optional)}
- *         </td>
- *         <td>{@code Optional.absent()}</td>
- *         <td>{@code Optional.present(other)}</td>
- *         <td>{@code Optional.present(other)}</td>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link
- *             Optional#or(Optional)}
- *         </td>
- *         <td>{@code Optional.absent()}</td>
- *         <td>{@code Optional.absent()}</td>
- *         <td>{@code Optional.absent()}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#orDefault(Object)}</td>
- *         <td>{@code Optional.present(value)}</td>
- *         <td>{@code other}</td>
- *         <td>{@code value}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#orDefault(Object)}</td>
- *         <td>{@code Optional.absent()}</td>
- *         <td>{@code other}</td>
- *         <td>{@code other}</td>
- *     </tr>
+ *   <caption>Querying Methods</caption>
+ *   <tr>
+ *     <th>Method</th>
+ *     <th>Receiver</th>
+ *     <th>Input</th>
+ *     <th>Output</th>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#or(Optional)}</td>
+ *     <td>{@code Optional.present(value)}</td>
+ *     <td>{@code Optional.present(other)}</td>
+ *     <td>{@code Optional.present(value)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#or(Optional)}</td>
+ *     <td>{@code Optional.present(value)}</td>
+ *     <td>{@code Optional.absent()}</td>
+ *     <td>{@code Optional.present(value)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#or(Optional)}</td>
+ *     <td>{@code Optional.absent()}</td>
+ *     <td>{@code Optional.present(other)}</td>
+ *     <td>{@code Optional.present(other)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#or(Optional)}</td>
+ *     <td>{@code Optional.absent()}</td>
+ *     <td>{@code Optional.absent()}</td>
+ *     <td>{@code Optional.absent()}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#orDefault(Object)}</td>
+ *     <td>{@code Optional.present(value)}</td>
+ *     <td>{@code other}</td>
+ *     <td>{@code value}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#orDefault(Object)}</td>
+ *     <td>{@code Optional.absent()}</td>
+ *     <td>{@code other}</td>
+ *     <td>{@code other}</td>
+ *   </tr>
  * </table>
  * <p>
  * Additionally, {@code Optional} provides several methods to transform its value. The simplest
  * being {@link Optional#map(java.util.function.Function)} which simply
  * applies the given {@link java.util.function.Function} to its value:
  * {@snippet :
- * Optional<Integer> present = Optional.present(5);
- * assert present.map(n -> n * 2).equals(Optional.present(10));
+ *   Optional<Integer> present = Optional.present(5);
+ *   assert present.map(n -> n * 2).equals(Optional.present(10));
  *
- * Optional<Integer> absent = Optional.absent();
- * assert absent.map(n -> n * 2).isAbsent();
+ *   Optional<Integer> absent = Optional.absent();
+ *   assert absent.map(n -> n * 2).isAbsent();
  * }
  * If the {@link java.util.function.Function} returns an {@code Optional},
  * {@link Optional#flatMap(java.util.function.Function)} can be used to
  * automatically flatten the return value:
  * {@snippet :
- * Optional<Integer> present = Optional.present(5);
- * assert present.flatMap(n -> Optional.present(n * 2)).equals(Optional.present(10));
- * assert present.flatMap(n -> Optional.absent()).isAbsent();
+ *   Optional<Integer> present = Optional.present(5);
+ *   assert present.flatMap(n -> Optional.present(n * 2)).equals(Optional.present(10));
+ *   assert present.flatMap(n -> Optional.absent()).isAbsent();
  *
- * Optional<Integer> absent = Optional.absent();
- * assert absent.flatMap(n -> Optional.present(n * 2)).isAbsent();
- * assert absent.flatMap(n -> Optional.absent()).isAbsent();
+ *   Optional<Integer> absent = Optional.absent();
+ *   assert absent.flatMap(n -> Optional.present(n * 2)).isAbsent();
+ *   assert absent.flatMap(n -> Optional.absent()).isAbsent();
  * }
  * <h2><a id="idioms">Idioms</a></h2>
  * <h3>Pattern Matching</h3>
@@ -122,10 +110,10 @@ import me.sparky983.helios.annotations.Nullable;
  * can be taken advantage of to make a type-safe call to
  * {@link Present#value()}:
  * {@snippet :
- * Optional<Integer> optional = Optional.present(5);
- * if (optional instanceof Present<Integer> present) {
+ *   Optional<Integer> optional = Optional.present(5);
+ *   if (optional instanceof Present<Integer> present) {
  *     System.out.println(present.value());
- * }
+ *   }
  * }
  * <h2>Null Interoperability</h2>
  * The use of {@code Optional} over {@code null} is highly encouraged, however there are times when
@@ -145,91 +133,84 @@ import me.sparky983.helios.annotations.Nullable;
  * <p>
  * A table that lists the differences is below.
  * <table border="1">
- *     <caption>{@link java.util.Optional java.util.Optional} comparison</caption>
- *     <tr>
- *         <th>
- *             {@link Optional me.sparky983.helios.optoinal.Optional}
- *         </th>
- *         <th>{@link java.util.Optional java.util.Optional}</th>
- *     </tr>
- *      <tr>
- *          <td>{@link Optional#absent()}</td>
- *          <td>{@link java.util.Optional#empty()}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#present(Object)}</td>
- *         <td>{@link java.util.Optional#of(Object)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#fromNullable(Object)}</td>
- *         <td>{@link java.util.Optional#ofNullable(Object)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#isPresent()}</td>
- *         <td>{@link java.util.Optional#isPresent()}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#isAbsent()}</td>
- *         <td>{@link java.util.Optional#isEmpty()}</td>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link
- *             Optional#or(Optional)}
- *         </td>
- *         <td>N/A</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#or(java.util.function.Supplier)}</td>
- *         <td>{@link java.util.Optional#or(java.util.function.Supplier)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#orDefault(Object)}</td>
- *         <td>{@link java.util.Optional#orElse(Object)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#orGet(java.util.function.Supplier)}</td>
- *         <td>{@link java.util.Optional#orElseGet(java.util.function.Supplier)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#orNull()}</td>
- *         <td>{@code java.util.Optional.orElse(null)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Optional#map(java.util.function.Function)}</td>
- *         <td>{@link java.util.Optional#map(java.util.function.Function)}</td>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link Optional#flatMap(java.util.function.Function)}
- *         </td>
- *         <td>{@link java.util.Optional#flatMap(java.util.function.Function)}</td>
- *     </tr>
- *     <tr>
- *         <td>
- *             {@link Optional#filter(java.util.function.Predicate)}
- *         </td>
- *         <td>{@link java.util.Optional#filter(java.util.function.Predicate)}</td>
- *     </tr>
- *     <tr>
- *         <td>{@link Present#value()}</td>
- *         <td>{@link java.util.Optional#get()}</td>
- *     </tr>
- *     <tr>
- *         <td>See <a href="#idioms">Idioms</a></td>
- *         <td>{@link java.util.Optional#ifPresent(java.util.function.Consumer)}</td>
- *    </tr>
- *    <tr>
- *        <td>See <a href="#idioms">Idioms</a></td>
- *        <td>
- *            {@link
- *            java.util.Optional#ifPresentOrElse(java.util.function.Consumer, java.lang.Runnable)}
- *        </td>
- *    </tr>
- *    <tr>
- *        <td>{@code Optional.map(Stream::of).orElse(Stream.of())}</td>
- *        <td>{@link java.util.Optional#stream()}</td>
- *    </tr>
+ *   <caption>{@link java.util.Optional java.util.Optional} comparison</caption>
+ *   <tr>
+ *     <th>{@code me.sparky983.helios.optional.Optional}</th>
+ *     <th>{@link java.util.Optional java.util.Optional}</th>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#absent()}</td>
+ *     <td>{@link java.util.Optional#empty()}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#present(Object)}</td>
+ *     <td>{@link java.util.Optional#of(Object)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#fromNullable(Object)}</td>
+ *     <td>{@link java.util.Optional#ofNullable(Object)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#isPresent()}</td>
+ *     <td>{@link java.util.Optional#isPresent()}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#isAbsent()}</td>
+ *     <td>{@link java.util.Optional#isEmpty()}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#or(Optional)}</td>
+ *     <td>N/A</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#or(java.util.function.Supplier)}</td>
+ *     <td>{@link java.util.Optional#or(java.util.function.Supplier)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#orDefault(Object)}</td>
+ *     <td>{@link java.util.Optional#orElse(Object)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#orGet(java.util.function.Supplier)}</td>
+ *     <td>{@link java.util.Optional#orElseGet(java.util.function.Supplier)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#orNull()}</td>
+ *     <td>{@code java.util.Optional.orElse(null)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#orThrow(java.util.function.Supplier)}</td>
+ *     <td>{@link java.util.Optional#orElseThrow(java.util.function.Supplier)}</td>
+ *   <tr>
+ *     <td>{@link Optional#map(java.util.function.Function)}</td>
+ *     <td>{@link java.util.Optional#map(java.util.function.Function)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#flatMap(java.util.function.Function)}</td>
+ *     <td>{@link java.util.Optional#flatMap(java.util.function.Function)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Optional#filter(java.util.function.Predicate)}</td>
+ *     <td>{@link java.util.Optional#filter(java.util.function.Predicate)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link Present#value()}</td>
+ *     <td>{@link java.util.Optional#get()}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>See <a href="#idioms">Idioms</a></td>
+ *     <td>{@link java.util.Optional#ifPresent(java.util.function.Consumer)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>See <a href="#idioms">Idioms</a></td>
+ *     <td>
+ *       {@link java.util.Optional#ifPresentOrElse(java.util.function.Consumer, java.lang.Runnable)}
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@code Optional.map(Stream::of).orElse(Stream.of())}</td>
+ *     <td>{@link java.util.Optional#stream()}</td>
+ *   </tr>
  * </table>
  * @param <T> the type of the value
  * @since 0.1.0
@@ -241,12 +222,12 @@ import me.sparky983.helios.annotations.Nullable;
  * This interface is sealed and the implementations are records, so you can easily combine switch
  * pattern matching and record patterns (Java 21+ features) to handle the different cases:
  * {@snippet :
- * Optional<String> optional = Optional.present("value");
- * switch (optional) {
+ *   Optional<String> optional = Optional.present("value");
+ *   switch (optional) {
  *     case Present(String value) -> System.out.println("Present: " + value);
  *     case Absent() -> System.out.println("Absent");
+ *   }
  * }
- *}
  */
 public sealed interface Optional<T extends Object> permits Present, Absent {
   /**
@@ -288,8 +269,8 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @helios.apiNote This method is intended to improve interoperability with null-based APIs.
    * @helios.examples
    * {@snippet :
-   * Map<String, String> map = Map.of("key", "value");
-   * Optional<String> optional = Optional.fromNullable(map.get("key"));
+   *   Map<String, String> map = Map.of("key", "value");
+   *   Optional<String> optional = Optional.fromNullable(map.get("key"));
    * }
    */
   static <T extends Object> Optional<T> fromNullable(final @Nullable T value) {
@@ -315,9 +296,9 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * {@code java.util.Optional}.
    * @helios.examples
    * {@snippet :
-   * java.util.Optional<String> javaUtilOptional = java.util.Optional.of("Java!");
-   * Optional<String> optional = Optional.from(javaUtilOptional);
-   *}
+   *   java.util.Optional<String> javaUtilOptional = java.util.Optional.of("Java!");
+   *   Optional<String> optional = Optional.from(javaUtilOptional);
+   * }
    */
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   static <T extends Object> Optional<T> from(final java.util.Optional<T> optional) {
@@ -330,12 +311,12 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @return {@code true} if this {@code Optional} is present, otherwise {@code false}
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> present = Optional.present(5);
-   * assert optional.isPresent();
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert optional.isPresent();
    *
-   * Optional<Integer> absent = Optional.absent();
-   * assert !absent.isPresent();
-   *}
+   *   Optional<Integer> absent = Optional.absent();
+   *   assert !absent.isPresent();
+   * }
    */
   boolean isPresent();
 
@@ -345,12 +326,12 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @return {@code true} if this {@code Optional} is absent, otherwise {@code false}
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> absent = Optional.absent();
-   * assert absent.isAbsent();
+   *   Optional<Integer> absent = Optional.absent();
+   *   assert absent.isAbsent();
    *
-   * Optional<Integer> present = Optional.present(5);
-   * assert !optional.isAbsent();
-   *}
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert !optional.isAbsent();
+   * }
    */
   boolean isAbsent();
 
@@ -362,12 +343,12 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the given {@code Optional} is {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> present = Optional.present(5);
-   * assert present.or(Optional.present(10)).equals(optional);
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert present.or(Optional.present(10)).equals(optional);
    *
-   * Optional<Integer> absent = Optional.absent();
-   * assert absent.or(Optional.present(10)).equals(Optional.present(10));
-   *}
+   *   Optional<Integer> absent = Optional.absent();
+   *   assert absent.or(Optional.present(10)).equals(Optional.present(10));
+   * }
    */
   Optional<T> or(Optional<? extends T> other);
 
@@ -379,16 +360,16 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the supplier is {@code null} or returns {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<String> findCachedUser(String username) {
+   *   Optional<String> findCachedUser(String username) {
    *     return Optional.absent(); // cache miss
-   * }
-   * Optional<String> findUser(String username) {
+   *   }
+   *   Optional<String> findUser(String username) {
    *     return Optional.present(username);
-   * }
+   *   }
    *
-   * Optional<String> user = findCachedUser("sparky983")
-   *         .or(() -> findUser("sparky983"));
-   *}
+   *   Optional<String> user = findCachedUser("sparky983")
+   *       .or(() -> findUser("sparky983"));
+   * }
    */
   Optional<T> or(Supplier<? extends Optional<? extends T>> otherSupplier);
 
@@ -400,12 +381,12 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the fallback value is {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> present = Optional.present(5);
-   * assert present.orDefault(10) == 5;
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert present.orDefault(10) == 5;
    *
-   * Optional<Integer> absent = Optional.absent();
-   * assert absent.orDefault(10) == 10;
-   *}
+   *   Optional<Integer> absent = Optional.absent();
+   *   assert absent.orDefault(10) == 10;
+   * }
    */
   T orDefault(T defaultValue);
 
@@ -419,12 +400,12 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the given supplier is {@code null} or returns {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> present = Optional.present(5);
-   * assert present.orGet(() -> 10) == 5;
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert present.orGet(() -> 10) == 5;
    *
-   * Optional<Integer> absent = Optional.absent();
-   * assert absent.orGet(() -> 10) == 10;
-   *}
+   *   Optional<Integer> absent = Optional.absent();
+   *   assert absent.orGet(() -> 10) == 10;
+   * }
    */
   T orGet(Supplier<? extends T> defaultValueSupplier);
 
@@ -435,9 +416,9 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @helios.apiNote This method is intended to improve interoperability with null-based APIs.
    * @helios.examples
    * {@snippet :
-   * String number = Optional.absent()
-   *         .map(Object::toString)
-   *         .orNull();
+   *   String number = Optional.absent()
+   *       .map(Object::toString)
+   *       .orNull();
    * }
    */
   @Nullable T orNull();
@@ -451,6 +432,15 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @return the value of this {@code Optional} if present
    * @throws NullPointerException if the given supplier is {@code null} or returns {@code null}.
    * @throws E if this {@code Optional} is absent
+   * @helios.examples
+   * {@snippet :
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert present.orThrow(IllegalStateException::new) == 5;
+   *
+   *   Optional<Integer> absent = Optional.absent();
+   *   absent.orThrow(IllegalStateException::new); // throws IllegalStateException
+   *   assert false; // unreachable
+   * }
    */
   <E extends Throwable> T orThrow(Supplier<? extends E> exceptionSupplier) throws E;
 
@@ -465,12 +455,12 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the given mapper is {@code null} or returns {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> present = Optional.present(5);
-   * assert present.map(n -> n * 2).equals(Optional.present(10));
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert present.map(n -> n * 2).equals(Optional.present(10));
    *
-   * Optional<Integer> absent = Optional.absent();
-   * assert absent.map(n -> n * 2).isAbsent();
-   *}
+   *   Optional<Integer> absent = Optional.absent();
+   *   assert absent.map(n -> n * 2).isAbsent();
+   * }
    */
   <M extends Object> Optional<M> map(Function<? super T, ? extends M> mapper);
 
@@ -485,15 +475,15 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the mapper is {@code null} or returns {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<User> findUser(String username) {
+   *   Optional<User> findUser(String username) {
    *     return Optional.present(User.builder()
-   *             .repository(Repository.named("helios"))
-   *             .build());
+   *         .repository(Repository.named("helios"))
+   *         .build());
    * }
    *
-   * Optional<Repository> repository = findUser("Sparky983")
-   *        .flatMap(user -> user.findRepository("helios"));
-   *}
+   *   Optional<Repository> repository = findUser("Sparky983")
+   *       .flatMap(user -> user.findRepository("helios"));
+   * }
    */
   <M extends Object> Optional<M> flatMap(
       Function<? super T, ? extends Optional<? extends M>> mapper);
@@ -508,10 +498,10 @@ public sealed interface Optional<T extends Object> permits Present, Absent {
    * @throws NullPointerException if the predicate is {@code null}.
    * @helios.examples
    * {@snippet :
-   * Optional<Integer> present = Optional.present(5);
-   * assert present.filter(n -> n % 2 == 1).equals(present);
-   * assert present.filter(n -> n % 2 == 0).isAbsent();
-   *}
+   *   Optional<Integer> present = Optional.present(5);
+   *   assert present.filter(n -> n % 2 == 1).equals(present);
+   *   assert present.filter(n -> n % 2 == 0).isAbsent();
+   * }
    */
   Optional<T> filter(Predicate<? super T> predicate);
 


### PR DESCRIPTION
This commit:
- Changes the Javadoc indentation to two spaces
- Indents snippet bodies by one
- Completes `Optional.orThrow(Exception)` documentation